### PR TITLE
Adding video object tracking with OpenCV trackers

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ I wanted this tool to give automatic suggestions for the labels!
 
 ## Quick start
 
-To start using the YOLO Bounding Box Tool you need to [download the latest release](https://github.com/Cartucho/OpenLabeling/archive/v1.2.zip) or clone the repo:
+To start using the YOLO Bounding Box Tool you need to [download the latest release](https://github.com/Cartucho/OpenLabeling/archive/v1.3.zip) or clone the repo:
 
 ```
 git clone https://github.com/Cartucho/OpenLabeling

--- a/box_predictor.py
+++ b/box_predictor.py
@@ -7,6 +7,7 @@
 #------------------------------------------------------------------------------------------------
 
 import os
+import glob
 import cv2
 
 class LabelTracker():
@@ -80,6 +81,13 @@ class LabelTracker():
         img_name = os.path.basename(os.path.normpath(img_path))
         img_type = img_path.split('.')[-1]
         return folder + img_name.replace(img_type, 'txt')
+
+    def remove_tmp_folder(self):
+        if os.path.exists('tmp/'):
+            file_list = glob.glob(os.path.abspath('tmp/') + str('/*.txt'))
+            for file in file_list:
+                os.remove(file)
+            os.rmdir('tmp')
 
     def yolo_format(self, class_index, point_1, point_2, width, height):
         x_center = (point_1[0] + point_2[0]) / float(2.0 * width)

--- a/box_predictor.py
+++ b/box_predictor.py
@@ -16,9 +16,9 @@ class LabelTracker():
         if not self.is_opencv_version_ok():
             raise Exception('OpenCV version is under v3')
 
-        self.imgs_path_list = imgs_path_list
-        self.create_tmp_txt_files()
+        self.remove_tmp_folder()
 
+        self.imgs_path_list = imgs_path_list
 
     def predict_next_imgs(self, current_img_index, num_imgs_to_predict):
         current_img = cv2.imread(self.imgs_path_list[current_img_index])
@@ -68,19 +68,19 @@ class LabelTracker():
         else:
             return True
 
-    def create_tmp_txt_files(self):
-        if not os.path.exists('tmp/'):
-            os.makedirs('tmp/')
-
-        for img_path in self.imgs_path_list:
-            txt_path = self.get_txt_path(img_path)
-            if not os.path.isfile(txt_path):
-                open(txt_path, 'a').close()
-
     def get_txt_path(self, img_path, folder='tmp/'):
         img_name = os.path.basename(os.path.normpath(img_path))
         img_type = img_path.split('.')[-1]
-        return folder + img_name.replace(img_type, 'txt')
+        txt_path = folder + img_name.replace(img_type, 'txt')
+
+        if folder == 'tmp/':
+            if not os.path.exists('tmp/'):
+                os.makedirs('tmp/')
+
+            if not os.path.isfile(txt_path):
+                open(txt_path, 'a').close()
+
+        return txt_path
 
     def remove_tmp_folder(self):
         if os.path.exists('tmp/'):

--- a/box_predictor.py
+++ b/box_predictor.py
@@ -7,19 +7,16 @@
 #------------------------------------------------------------------------------------------------
 
 import os
-import numpy as np
 import cv2
 
 class LabelTracker():
-    def __init__(self, imgs_path_list, type='KCF'):
+    def __init__(self, imgs_path_list):
 
         if not self.is_opencv_version_ok():
             raise Exception('OpenCV version is under v3')
 
         self.imgs_path_list = imgs_path_list
         self.create_tmp_txt_files()
-
-        self.tracker_type = type
 
 
     def predict_next_imgs(self, current_img_index, num_imgs_to_predict):
@@ -45,8 +42,10 @@ class LabelTracker():
                 x_tl = x_center*current_img_width - (x_width*current_img_width/2.0)
                 y_tl = y_center*current_img_height - (y_height*current_img_height/2.0)
                 roi = (x_tl, y_tl, x_width*current_img_width, y_height*current_img_height)
+
                 tracker = cv2.TrackerKCF_create()
                 tracker.init(current_img, roi)
+
                 classWithTracker.append((class_index, tracker))
 
             # predict

--- a/box_predictor.py
+++ b/box_predictor.py
@@ -59,7 +59,19 @@ class LabelTracker():
                             line = self.yolo_format(class_index, (bbox[0], bbox[1]),
                                                     (bbox[0]+bbox[2], bbox[1]+bbox[3]),
                                                     current_img_width, current_img_height)
-                            f.write(line + "\n")
+                            if not self.is_line_already_in_file(line, temp_txt_path):
+                                f.write(line + "\n")
+
+    def is_line_already_in_file(self, new_line, file_path):
+        file = open(file_path)
+        content = file.readlines()
+        for line in content:
+            if line == new_line:
+                file.close()
+                return True
+        file.close()
+        return False
+
 
     def is_opencv_version_ok(self):
         (major_ver, minor_ver, subminor_ver) = (cv2.__version__).split('.')

--- a/box_predictor.py
+++ b/box_predictor.py
@@ -1,0 +1,90 @@
+#------------------------------------------------------------------------------------------------
+#
+# By: Rafael Caballero Gonzalez
+#
+# Trying to predict labels in the next frames using OpenCV trackers
+#
+#------------------------------------------------------------------------------------------------
+
+import os
+import numpy as np
+import cv2
+
+class LabelTracker():
+    def __init__(self, imgs_path_list, type='KCF'):
+
+        if not self.is_opencv_version_ok():
+            raise Exception('OpenCV version is under v3')
+
+        self.imgs_path_list = imgs_path_list
+        self.create_tmp_txt_files()
+
+        self.tracker_type = type
+
+
+    def predict_next_imgs(self, current_img_index, num_imgs_to_predict):
+        current_img = cv2.imread(self.imgs_path_list[current_img_index])
+
+        if len(self.imgs_path_list) > 1:
+            next_imgs_path_list = self.imgs_path_list[current_img_index+1:current_img_index+num_imgs_to_predict]
+            next_imgs = list()
+            for next_img in next_imgs_path_list:
+                next_imgs.append(cv2.imread(next_img))
+
+            current_img_height, current_img_width, current_img_channels = current_img.shape
+
+            classWithTracker = list()
+
+            # load current bboxes
+            txt_path = self.get_txt_path(self.imgs_path_list[current_img_index], 'bbox_txt/')
+            with open(txt_path) as f:
+                content = f.readlines()
+            for line in content:
+                values_str = line.split()
+                class_index, x_center, y_center, x_width, y_height = map(float, values_str)
+                roi = (x_center*current_img_width, y_center*current_img_height, x_width*current_img_width, y_height*current_img_height)
+                tracker = cv2.TrackerKCF_create()
+                tracker.init(current_img, roi)
+                classWithTracker.append((class_index, tracker))
+
+            # predict
+            for i in range(0, len(next_imgs_path_list), 1):
+                temp_txt_path = self.get_txt_path(next_imgs_path_list[i])
+                with open(temp_txt_path, 'a') as f:
+                    for class_index, tracker in classWithTracker:
+                        ok, bbox = tracker.update(next_imgs[i])
+                        if ok:
+                            line = self.yolo_format(class_index, (bbox[0], bbox[1]),
+                                                    (bbox[0]+bbox[2], bbox[1]+bbox[3]),
+                                                    current_img_width, current_img_height)
+                            f.write(line + "\n")
+
+    def is_opencv_version_ok(self):
+        (major_ver, minor_ver, subminor_ver) = (cv2.__version__).split('.')
+        if int(minor_ver) < 3:
+            return False
+        else:
+            return True
+
+    def create_tmp_txt_files(self):
+        if not os.path.exists('tmp/'):
+            os.makedirs('tmp/')
+
+        for img_path in self.imgs_path_list:
+            txt_path = self.get_txt_path(img_path)
+            if not os.path.isfile(txt_path):
+                open(txt_path, 'a').close()
+
+    def get_txt_path(self, img_path, folder='tmp/'):
+        img_name = os.path.basename(os.path.normpath(img_path))
+        img_type = img_path.split('.')[-1]
+        return folder + img_name.replace(img_type, 'txt')
+
+    def yolo_format(self, class_index, point_1, point_2, width, height):
+        x_center = (point_1[0] + point_2[0]) / float(2.0 * width)
+        y_center = (point_1[1] + point_2[1]) / float(2.0 * height)
+        x_width = float(abs(point_2[0] - point_1[0])) / width
+        y_height = float(abs(point_2[1] - point_1[1])) / height
+        return str(class_index) + " " + str(x_center) \
+               + " " + str(y_center) + " " + str(x_width) + " " + str(y_height)
+

--- a/box_predictor.py
+++ b/box_predictor.py
@@ -42,7 +42,9 @@ class LabelTracker():
             for line in content:
                 values_str = line.split()
                 class_index, x_center, y_center, x_width, y_height = map(float, values_str)
-                roi = (x_center*current_img_width, y_center*current_img_height, x_width*current_img_width, y_height*current_img_height)
+                x_tl = x_center*current_img_width - (x_width*current_img_width/2.0)
+                y_tl = y_center*current_img_height - (y_height*current_img_height/2.0)
+                roi = (x_tl, y_tl, x_width*current_img_width, y_height*current_img_height)
                 tracker = cv2.TrackerKCF_create()
                 tracker.init(current_img, roi)
                 classWithTracker.append((class_index, tracker))
@@ -85,6 +87,7 @@ class LabelTracker():
         y_center = (point_1[1] + point_2[1]) / float(2.0 * height)
         x_width = float(abs(point_2[0] - point_1[0])) / width
         y_height = float(abs(point_2[1] - point_1[1])) / height
-        return str(class_index) + " " + str(x_center) \
-               + " " + str(y_center) + " " + str(x_width) + " " + str(y_height)
+        return str(int(class_index)) + " " + str(round(x_center, 6)) \
+               + " " + str(round(y_center, 6)) + " " + str(round(x_width, 6)) \
+               + " " + str(round(y_height, 6))
 

--- a/run.py
+++ b/run.py
@@ -490,12 +490,14 @@ while True:
             
     # quit key listener
     elif pressed_key == ord('q'):
+        label_tracker.remove_tmp_folder()
         break
     """ Key Listeners END """
 
     if WITH_QT:
         # if window gets closed then quit
         if cv2.getWindowProperty(WINDOW_NAME,cv2.WND_PROP_VISIBLE) < 1:
+            label_tracker.remove_tmp_folder()
             break
 
 cv2.destroyAllWindows()


### PR DESCRIPTION
Hey!

I'm working on adding the video tracking feature as I mentioned in #3. 

I added a new module "box_predictor.py" which tries to be as independent as it can (I'm sure it could be more). It uses the KCF tracker from OpenCV in order to predict the same box in the nex images. It depends on a folder "tmp/" that is created when running. Also, images must be sorted beforehand.

In order to make it work, put some video frames in the images folder. Then start run.py, select the boxes as usual and press key "p" to predict the next N frames. N could be selected beforehand in the new bar introduced.

So far the predicted boxes aren't saved in its main .txt file. I'm looking the way to improve all this process. Also, I think a way to "validate" somehow the predictions is needed before included them in the main .txt.

This PR is just a start point in order to put in common impressions and ideas. Feel free to discuss!